### PR TITLE
Add 02-learn more about the OS community

### DIFF
--- a/src/00-introduction/02-learn-more-about-the-os-community.md
+++ b/src/00-introduction/02-learn-more-about-the-os-community.md
@@ -1,0 +1,198 @@
+# Joining the Culture of Open Science
+
+## Learning about open science
+
+### Blogs
+
+#### General 
+
+-   Center for Open Science: [https://cos.io/blog/](https://www.google.com/url?q=https://cos.io/blog/&sa=D&ust=1596500749162000&usg=AOvVaw3uJDhefB1mUKm3se6viTG3)
+-   Data Colada: [http://datacolada.org/](https://www.google.com/url?q=http://datacolada.org/&sa=D&ust=1596500749163000&usg=AOvVaw0YjT_VxdSsrr6IpyAVb4GR)
+-   Simine Vazire (University of Melbourne): [https://sometimesimwrong.typepad.com/](https://www.google.com/url?q=https://sometimesimwrong.typepad.com/&sa=D&ust=1596500749164000&usg=AOvVaw2HnMYptGc5O7vx0COFhHKM)
+
+#### Psychology
+
+-   Michael Frank (Stanford):  [http://babieslearninglanguage.blogspot.com/search/label/Reproducibility](https://www.google.com/url?q=http://babieslearninglanguage.blogspot.com/search/label/Reproducibility&sa=D&ust=1596500749163000&usg=AOvVaw04OkownbbJhZ3zytZKVKrZ)
+-   Russ Poldrack (Stanford): [http://www.russpoldrack.org/](https://www.google.com/url?q=http://www.russpoldrack.org/&sa=D&ust=1596500749164000&usg=AOvVaw0NaUWBworM2k6IpdwG1yi9)
+-   Sanjay Srivastava (University of Oregon): [https://thehardestscience.com/](https://www.google.com/url?q=https://thehardestscience.com/&sa=D&ust=1596500749164000&usg=AOvVaw1b1pVcxvw3YBKcFGnEwQYK)
+
+### Books
+
+#### Psychology and social science
+
+-   Understanding Psychology as a Science (Zoltan Dienes): [https://www.amazon.com/Understanding-Psychology-Science-Introduction-Statistical/dp/B00FGVUQWU](https://www.google.com/url?q=https://www.amazon.com/Understanding-Psychology-Science-Introduction-Statistical/dp/B00FGVUQWU&sa=D&ust=1596500749165000&usg=AOvVaw0BF5KzEe0Sy_uZPwgZv185)
+-   Transparent Reproducible Social Science (Garret Christensen, Jeremy Freese, Edward Miguel): [https://www.amazon.com/Transparent-Reproducible-Social-Science-Research/dp/0520296958](https://www.google.com/url?q=https://www.amazon.com/Transparent-Reproducible-Social-Science-Research/dp/0520296958&sa=D&ust=1596500749166000&usg=AOvVaw3rrPildSSZwp_t23RPljgT)
+
+#### Biomedical research
+
+-   Rigor Mortis (Richard Harris): [https://www.amazon.com/Rigor-Mortis-Science-Worthless-Billions/dp/0465097901](https://www.google.com/url?q=https://www.amazon.com/Rigor-Mortis-Science-Worthless-Billions/dp/0465097901&sa=D&ust=1596500749165000&usg=AOvVaw1pkIOag-K0HG15JrWjznYL)
+
+### Courses
+
+-   Stanford Courses
+    -   CHPR 206: Meta-research: Appraising Research Findings, Bias, and Meta-analysis
+        -   Instructor: [John Ioannidis](https://www.google.com/url?q=https://www.google.com/search?sxsrf%3DALeKk01eOlKD3O1FbqlHV8USln1mBnVqnQ:1585943292138%26q%3Djohn%2Bioannidis%26spell%3D1%26sa%3DX%26ved%3D2ahUKEwjA9r6Ug83oAhWUqp4KHQR-AQgQkeECKAB6BAgVECc&sa=D&ust=1596500749167000&usg=AOvVaw2qyxSZe5ii4olBvpdCPGGX)
+    -   PSYCH 251: Statistical Methods for Behavioral and Social Sciences
+        -   Instructor: Mike Frank
+        -   Link to older version of class: [https://web.stanford.edu/class/psych254/](https://www.google.com/url?q=https://web.stanford.edu/class/psych254/&sa=D&ust=1596500749167000&usg=AOvVaw0r511xAEOwLTXj2udmQTj7)
+-   HRP 264: Foundations of Statistical and Scientific Inference
+    -   Instructor: Steven Goodman
+-   MED73N: Scientific Method and Bias
+    -   Instructor: John Ioannidis
+
+-   External Courses
+    -   List of open science/reproducibility syllabi: [https://osf.io/vkhbt/wiki/home/](https://www.google.com/url?q=https://osf.io/vkhbt/wiki/home/&sa=D&ust=1596500749168000&usg=AOvVaw2F3n8G9of2kTl5eNE59SM6)
+    -   Neuro summer workshop at University of Washington:  [https://neurohackademy.org](https://www.google.com/url?q=https://neurohackademy.org/&sa=D&ust=1596500749168000&usg=AOvVaw0_oXCRMuvWNVZJSEXwVQlb)
+    -   Daniel Lakens’ Coursera courses:
+        -   [https://www.coursera.org/learn/statistical-inferences](https://www.google.com/url?q=https://www.coursera.org/learn/statistical-inferences&sa=D&ust=1596500749169000&usg=AOvVaw3TLih9DP0MjPkcGIGKGdha)
+        -   [https://www.coursera.org/learn/improving-statistical-questions](https://www.google.com/url?q=https://www.coursera.org/learn/improving-statistical-questions&sa=D&ust=1596500749169000&usg=AOvVaw0DzZL7xz7vCyknIQSM2pHe)
+
+-   [Karl Broman tutorials on reproducible research:](https://kbroman.org/pages/tutorials) 
+
+### People/Twitter Handles
+
+-   Andrew Gelman: @StatModeling
+-   Brian Nosek: @BrianNosek
+-   Charlie Ebersole: @CharlieEbersole
+-   Chris Gorgolewski: @chrisgorgo
+-   Daniël Lakens: @lakens
+-   Eiko Fried: @EikoFried
+-   EJ Wagenmakers: @EJWagenmakers
+-   Joe Simmons: @jpsimmon
+-   John Ioannidis: (no twitter)
+-   Marcus Munafò: @MarcusMunafo
+-   Michael C. Frank: @mcxfrank
+-   Neil Lewis, Jr.: @NeilLewisJr
+-   Rickard Carlsson: @RickCarlsson
+-   Russ Poldrack: @russpoldrack
+-   Sanjay Srivastava: @hardsci
+-   Simine Vazire: @siminevazire
+-   Steven Goodman: @goodmanmetrics
+-   Tal Yarkoni: @talyarkoni
+-   Uri Simonsohn: @uri_sohn
+
+### Podcasts
+
+#### General 
+
+-   Everything Hertz: [https://everythinghertz.com/](https://www.google.com/url?q=https://everythinghertz.com/&sa=D&ust=1596500749172000&usg=AOvVaw2nWYsaStG3iMR5Fu2C31tF)
+-   Marginally Significant: [https://marginallysignificant.fireside.fm/](https://www.google.com/url?q=https://marginallysignificant.fireside.fm/&sa=D&ust=1596500749173000&usg=AOvVaw3NegcGyyn5Jo6DY4HOUj2v)
+-   Open Science Radio: [http://www.openscienceradio.org/](https://www.google.com/url?q=http://www.openscienceradio.org/&sa=D&ust=1596500749173000&usg=AOvVaw2LJJEu6Edon7KxEVlh-J6A)
+-   ReproducibiliTea: [https://podcasts.apple.com/gb/podcast/reproducibilitea-podcast/id1406176044](https://www.google.com/url?q=https://podcasts.apple.com/gb/podcast/reproducibilitea-podcast/id1406176044&sa=D&ust=1596500749173000&usg=AOvVaw14DBL_U_LiAfFvv7tdXv9z)
+
+#### Psychology
+
+-   The Black Goat: [http://www.theblackgoatpodcast.com/](https://www.google.com/url?q=http://www.theblackgoatpodcast.com/&sa=D&ust=1596500749174000&usg=AOvVaw2jtTMhQ9OoDT2ic9sCTN7i)
+-   Two Psychologists Four Beers: [https://fourbeers.fireside.fm/](https://www.google.com/url?q=https://fourbeers.fireside.fm/&sa=D&ust=1596500749174000&usg=AOvVaw0tsSxWL9TWeA4YzQlbvj4-)
+
+#### Select open science episodes
+
+-   \*Quantitude: [https://quantitudethepodcast.org/](https://www.google.com/url?q=https://quantitudethepodcast.org/&sa=D&ust=1596500749175000&usg=AOvVaw3BbD9aXzqF2wadZs5nF3ZB)
+-   \*Very Bad Wizards: [https://verybadwizards.fireside.fm/](https://www.google.com/url?q=https://verybadwizards.fireside.fm/&sa=D&ust=1596500749175000&usg=AOvVaw18HhrEp2-8m7PN-mH58AZe)
+
+\*Not devoted solely to open science, but have relevant episodes
+
+### Foundational papers
+
+-   Open Science Collaboration. (2015). Estimating the reproducibility of psychological science. Science, 349(6251), aac4716. [https://doi.org/10.1126/science.aac4716](https://www.google.com/url?q=https://doi.org/10.1126/science.aac4716&sa=D&ust=1596500749176000&usg=AOvVaw1DZLKbHrAKyfKIFs_9M9dB)
+-   Simmons, J. P., Nelson, L. D., & Simonsohn, U. (2011). False-positive psychology: Undisclosed flexibility in data collection and analysis allows presenting anything as significant. Psychological science, 22(11), 1359-1366. [https://doi.org/10.1177/0956797611417632](https://www.google.com/url?q=https://doi.org/10.1177%252F0956797611417632&sa=D&ust=1596500749176000&usg=AOvVaw1cb8FJYHaeoBOC4iykeoZq)
+-   Ioannidis, J. P. (2005). Why most published research findings are false. PLos Med, 2(8), e124. [https://doi.org/10.1371/journal.pmed.0020124](https://www.google.com/url?q=https://doi.org/10.1371/journal.pmed.0020124&sa=D&ust=1596500749177000&usg=AOvVaw3xFuvlYoK7OnB_GrIzd3_o)
+-   Watson, M. (2015). When will ‘open science’ become simply ‘science’?. Genome biology, 16(1), 1-3. [https://doi.org/10.1186/s13059-015-0669-2](https://www.google.com/url?q=https://doi.org/10.1186/s13059-015-0669-2&sa=D&ust=1596500749177000&usg=AOvVaw06O8MDsMD60ne0S63qgJIh)
+-   Nosek, B. A., Alter, G., Banks, G. C., Borsboom, D., Bowman, S. D., Breckler, S. J., ... & Contestabile, M. (2015). Promoting an open research culture. Science, 348(6242), 1422-1425. [https://doi.org/10.1126/science.aab2374](https://www.google.com/url?q=https://doi.org/10.1126/science.aab2374&sa=D&ust=1596500749178000&usg=AOvVaw0bVBZEEQQ44LDq91dK1XnA)
+-   Wagenmakers, E. J., Wetzels, R., Borsboom, D., van der Maas, H. L., & Kievit, R. A. (2012). An agenda for purely confirmatory research. Perspectives on Psychological Science, 7(6), 632-638. [https://doi.org/10.1177/1745691612463078](https://www.google.com/url?q=https://doi.org/10.1177%252F1745691612463078&sa=D&ust=1596500749178000&usg=AOvVaw0xNoDsfRNsMv2AAscOi-6X)
+-   Munafò, M. R., Nosek, B. A., Bishop, D. V., Button, K. S., Chambers, C. D., Du Sert, N. P., ... & Ioannidis, J. P. (2017). A manifesto for reproducible science. Nature human behaviour, 1(1), 1-9. [https://doi.org/10.1038/S41562-016-0021](https://www.google.com/url?q=https://doi.org/10.1038/S41562-016-0021&sa=D&ust=1596500749179000&usg=AOvVaw3FumsT4fy7diCN80Q1SKJq)
+-   Levin, N., & Leonelli, S. (2017). How does one “open” science? Questions of value in biological research. Science, Technology, & Human Values, 42(2), 280-305. [https://doi.org/10.1177/0162243916672071](https://www.google.com/url?q=https://doi.org/10.1177/0162243916672071&sa=D&ust=1596500749179000&usg=AOvVaw1Rhsx1Qvns_ENaqj5sw2_n)
+-   Gorgolewski, K. J., & Poldrack, R. A. (2016). A practical guide for improving transparency and reproducibility in neuroimaging research. PLoS biology, 14(7). [https://doi.org/10.1371/journal.pbio.1002506](https://www.google.com/url?q=https://doi.org/10.1371/journal.pbio.1002506&sa=D&ust=1596500749180000&usg=AOvVaw2cDdLavcEVPLror5hw9FHe)
+-   Byers-Heinlein, K., Bergmann, C., Davies, C., Frank, M. C., Hamlin, J. K., Kline, M., ... & Mastroberardino, M. (2020). [Building a collaborative psychological science: Lessons learned from ManyBabies 1](https://www.google.com/url?q=http://eprints.whiterose.ac.uk/157387/1/Byers-HeinleinEtAl-Lessons_Learned_From_ManyBabies1.pdf&sa=D&ust=1596500749180000&usg=AOvVaw0zypNYfpMvrKODkvpwZ4rB). Canadian Psychology.
+
+### Talks
+
+#### General 
+
+-   Metascience 2019 Symposium: [https://www.metascience2019.org/presentations/](https://www.google.com/url?q=https://www.metascience2019.org/presentations/&sa=D&ust=1596500749181000&usg=AOvVaw2qEoqicWP15uXs6DmAfFji)
+
+#### Psychology
+
+-   Association for Psychological Science: Improving the Reproducibility of Our Research Practices: [https://www.youtube.com/playlist?list=PLMOU-iLiJIc0amNVabGXJ0liKwIwxqkO8](https://www.google.com/url?q=https://www.youtube.com/playlist?list%3DPLMOU-iLiJIc0amNVabGXJ0liKwIwxqkO8&sa=D&ust=1596500749181000&usg=AOvVaw0vyTM3uh6neCDEUBWGh_p3)
+
+## Doing open science
+
+### Tools/Platforms
+
+#### General
+
+-   Open Science Framework: [https://osf.io/](https://www.google.com/url?q=https://osf.io/&sa=D&ust=1596500749182000&usg=AOvVaw0mcPDL1bzVK3OOb73cBMGJ)
+-   GitHub: [https://github.com/](https://www.google.com/url?q=https://github.com/&sa=D&ust=1596500749183000&usg=AOvVaw0WAISHsyptJpEF5I5knlEV)
+-   AsPredicted: [https://aspredicted.org/](https://www.google.com/url?q=https://aspredicted.org/&sa=D&ust=1596500749183000&usg=AOvVaw26Ku559n9IANIdRK-MUp6v)
+
+#### Psychology
+
+-   PsyArXiv: [https://psyarxiv.com/](https://www.google.com/url?q=https://psyarxiv.com/&sa=D&ust=1596500749183000&usg=AOvVaw3F0_zfITRs-l0gDFGkVJVe)
+
+### Initiatives/Collaborations
+
+#### Psychology and brain science
+
+-   Many Labs: [https://osf.io/89vqh/](https://www.google.com/url?q=https://osf.io/89vqh/&sa=D&ust=1596500749184000&usg=AOvVaw2LWVESIx35eBenI_uk6k19)
+-   Psychological Science Accelerator: [https://psysciacc.org/](https://www.google.com/url?q=https://psysciacc.org/&sa=D&ust=1596500749184000&usg=AOvVaw0Iiu7V_gsyKPvZzqK6ujZu) 
+-   Open Neuro: [https://openneuro.org/](https://www.google.com/url?q=https://openneuro.org/&sa=D&ust=1596500749185000&usg=AOvVaw2i4GfwPgsG0ftjKWXNLV4V)
+-   Cognitive Atlas: [http://www.cognitiveatlas.org/](https://www.google.com/url?q=http://www.cognitiveatlas.org/&sa=D&ust=1596500749185000&usg=AOvVaw3jUfc8I5u_UjugwvFpqyqY)
+-   NeuroVault: [https://neurovault.org/](https://www.google.com/url?q=https://neurovault.org/&sa=D&ust=1596500749185000&usg=AOvVaw3a0oWdxxAstrBagGX-IUey)
+-   Many Babies: [https://osf.io/rpw6d/](https://www.google.com/url?q=https://osf.io/rpw6d/&sa=D&ust=1596500749185000&usg=AOvVaw00BJ-etRWH4AoBgZ72dvVr)
+
+#### Social science
+
+-   repliCATS: [https://replicats.research.unimelb.edu.au/](https://www.google.com/url?q=https://replicats.research.unimelb.edu.au/&sa=D&ust=1596500749184000&usg=AOvVaw0gy2FLC0ZEURxNLnxN97K_)
+
+### Organizations/Centers/Labs
+
+#### General
+
+-   Stanford METRICS: [https://metrics.stanford.edu/](https://www.google.com/url?q=https://metrics.stanford.edu/&sa=D&ust=1596500749187000&usg=AOvVaw1b76VmdxeUeozMYs-Emrko)
+-   Center for Open Science: [https://cos.io/](https://www.google.com/url?q=https://cos.io/&sa=D&ust=1596500749186000&usg=AOvVaw3JCdhY1ocDq4ASAA6P3OOp)
+-   Credibility Lab: [https://credlab.wharton.upenn.edu/](https://www.google.com/url?q=https://credlab.wharton.upenn.edu/&sa=D&ust=1596500749187000&usg=AOvVaw0YqvROdpRCtM3QHcCl-oiu)
+-   Research on Research Institute: [http://researchonresearch.org/](https://www.google.com/url?q=http://researchonresearch.org/&sa=D&ust=1596500749187000&usg=AOvVaw3kfQfOk8Mmc5I8LPXlGp1-)
+
+#### Psychology and brain science
+
+-   Stanford Center for Reproducible Neuroscience: [https://reproducibility.stanford.edu/](https://www.google.com/url?q=https://reproducibility.stanford.edu/&sa=D&ust=1596500749188000&usg=AOvVaw08p3np8Nmk9-vbGk2ImnV5)
+
+#### Social science
+
+-   BITSS: [https://www.bitss.org/](https://www.google.com/url?q=https://www.bitss.org/&sa=D&ust=1596500749186000&usg=AOvVaw35Y7mzQMBRSRP9eQ2ts3Bu)
+
+### Societies/Conferences
+
+#### General 
+
+-   Metascience Symposium: [https://www.metascience2019.org/](https://www.google.com/url?q=https://www.metascience2019.org/&sa=D&ust=1596500749188000&usg=AOvVaw1aFqiVdJGo9pJWznLTBnik)
+
+#### Psychology and brain science
+
+-   Society for Improving Psychological Science (SIPS): [https://improvingpsych.org/](https://www.google.com/url?q=https://improvingpsych.org/&sa=D&ust=1596500749189000&usg=AOvVaw0lvK84oqPBphdJe_Jz3sBZ)
+-   Organization of Human Brain Mapping (OHBM) [https://humanbrainmapping.org](https://www.google.com/url?q=https://humanbrainmapping.org&sa=D&ust=1596500749188000&usg=AOvVaw1CLpdG82AU3fmB9VLFnRS8)
+
+### Hackathons
+
+#### Psychology and brain science
+
+-   [https://neurohackademy.org/](https://www.google.com/url?q=https://neurohackademy.org/&sa=D&ust=1596500749189000&usg=AOvVaw0NZ-E16F3R5_IfOP8LcTHo)
+-   [https://www.brainhack.org/](https://www.google.com/url?q=https://www.brainhack.org/&sa=D&ust=1596500749190000&usg=AOvVaw09IJP0PYA2DnzccxwljHJq)
+
+### Journals
+
+TOP guidelines: journal rankings by open science practices: [https://cos.io/top/](https://www.google.com/url?q=https://cos.io/top/&sa=D&ust=1596500749190000&usg=AOvVaw2sfJ5Ig-A8dWMY46E9C7wq)
+
+#### Specific journals
+
+-   Advances in Methods and Practices in Psychological Science: [https://journals.sagepub.com/home/ampa](https://www.google.com/url?q=https://journals.sagepub.com/home/ampa&sa=D&ust=1596500749191000&usg=AOvVaw1qrk5bzVRXcfb4R6WuNaor)
+-   Collabra: Psychology: [https://www.collabra.org/](https://www.google.com/url?q=https://www.collabra.org/&sa=D&ust=1596500749191000&usg=AOvVaw3Fp2QYG1jQR85AzcMGAOZJ)
+-   Meta-Psychology: [https://open.lnu.se/index.php/metapsychology/about](https://www.google.com/url?q=https://open.lnu.se/index.php/metapsychology/about&sa=D&ust=1596500749191000&usg=AOvVaw1uDDbnctUleHjhBQm4fsqx)
+
+### Funding & Grants
+
+-   NSF: Open Science for Research Data: [https://nsf.gov/pubs/2020/nsf20068/nsf20068.jsp](https://www.google.com/url?q=https://nsf.gov/pubs/2020/nsf20068/nsf20068.jsp&sa=D&ust=1596500749192000&usg=AOvVaw2v_ZnXiikK_5Mt_3LqPyM7)
+    -   Posted March 27, 2020
+
+-   List of funding types offered through the NSF’s Science of Science and Innovation Policy: [https://www.nsf.gov/funding/pgm_summ.jsp?pims_id=501084](https://www.google.com/url?q=https://www.nsf.gov/funding/pgm_summ.jsp?pims_id%3D501084&sa=D&ust=1596500749192000&usg=AOvVaw33_Cmovh-zr3QGRw3VF_OA)
+


### PR DESCRIPTION
This PR adds in a list of resources for diving deeper into the open science community. I added an organizational layer to denote the domain each resource pertains to. This will help initialize the space for the community to build out domain-specific   resources